### PR TITLE
Allow '.hostname' additional to '.host' in requestoptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,7 +292,7 @@ globalTunnel._makeRequest = function(httpOrHttps, protocol) {
     if (
       (options.agent === null || options.agent === undefined) &&
       typeof options.createConnection !== 'function' &&
-      options.host
+      (options.host || options.hostname) 
     ) {
       options.agent = options._defaultAgent || httpOrHttps.globalAgent;
     }


### PR DESCRIPTION
see #14